### PR TITLE
Update Crowdin link

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -65,7 +65,7 @@ __Now：[qqlittleice/MiuiHome](https://github.com/qqlittleice/MiuiHome)__
 
 ## Translation Contributions
 
-[Crowdin](https://zh.crowdin.com/project/miuihome_xposed)
+[Crowdin](https://crowdin.com/project/miuihome_xposed)
 
 ## Credits
 


### PR DESCRIPTION
Current Crowdin link for EN Readme is Chinese, changed the link to English domain.